### PR TITLE
fix: ensure our capf comes before others

### DIFF
--- a/conventional-commit.el
+++ b/conventional-commit.el
@@ -98,7 +98,7 @@ can be a list of strings or a dynamic completion table created by
 (defun conventional-commit-setup ()
   "Set up `completion-at-point-functions' for the current buffer."
   (add-hook 'completion-at-point-functions #'conventional-commit-capf
-            'append 'local))
+            nil 'local))
 
 (provide 'conventional-commit)
 ;;; conventional-commit.el ends here


### PR DESCRIPTION
Our capf is very specific (only activating on the first line, and only when either there is a single word or we're matching inside brackets for scope). It can therefore come early in the matching list, allowing it to activate before other capf's that may match in many circumstances (e.g. cape-dabbrev)

Ref: #5
